### PR TITLE
Enable support for object spread operator

### DIFF
--- a/template/build/vue-loader.config.js
+++ b/template/build/vue-loader.config.js
@@ -3,5 +3,8 @@ module.exports = {
     require('autoprefixer')({
       browsers: ['last 3 versions']
     })
-  ]
+  ],
+  buble: {
+    objectAssign: 'Object.assign',
+  },
 }


### PR DESCRIPTION
I'll be honest, I don't really know how this works or how it should work, but for whatever reason, having the `objectAssign` option for buble in `webpack.base.config.js` is not enough to actually enable the feature. It has to be added to `vue-loader.config.js`.

Example:

```js
  computed: {
    ...mapGetters({
      transactions: 'allTransactions',
    }),
  },
```

Without adding the option to `vue-loader-config.js`, the following error is reported.

```
Object spread operator requires specified objectAssign option with 'Object.assign' or polyfill helper.
```

After adding the option, it seems to transpile correctly.

[Reference](https://github.com/vuejs/vue-hackernews-2.0/issues/87)