### PR TITLE
Fix click on toolbar icon when navigation drawer is hidden

### DIFF
--- a/template/assets/App.vue
+++ b/template/assets/App.vue
@@ -23,7 +23,7 @@
       </v-list>
     </v-navigation-drawer>
     <v-toolbar fixed>
-      <v-toolbar-side-icon @click="drawer = !drawer"></v-toolbar-side-icon>
+      <v-toolbar-side-icon @click.stop="drawer = !drawer"></v-toolbar-side-icon>
       <v-btn 
         icon
         @click.native.stop="miniVariant = !miniVariant"


### PR DESCRIPTION
If your screen has a small resolution (horizontally, smaller than 1264 if I am not wrong - https://vuetifyjs.com/layout/grid), v-navigation-drawer by default is hidden, and you should be able to make it visible by clicking on v-toolbar-side-icon. Currently, this is not working, my commit should fix that.